### PR TITLE
Update past events. Add aws re:invent to upcoming events

### DIFF
--- a/PAST.md
+++ b/PAST.md
@@ -37,5 +37,12 @@
 | 6-7 October 2021 | [TransformX AI Conference](https://www.aicamp.ai/event/eventdetails/W2021100608) | AI/ML/Robotiics | online | free | n/a |
 | 10 October 2021 | [Open Source India](https://www.opensourceindia.in) | Software | online | free | n/a |
 | 10-12 October 2021 | [Open Networking & Edge Summit + Kubernetes on Edge Day](https://events.linuxfoundation.org/open-networking-edge-summit-north-america/) | edge | online & Los Angeles, USA | $50(before Oct 05)/$150 | [20 June 2021](https://events.linuxfoundation.org/open-networking-edge-summit-north-america/program/cfp/) |
+| 12-14 October 2021 | [Google Cloud Next 2021](https://cloud.withgoogle.com/next) | All things Google Cloud | Online | Free | n/a |
+| 11-15 October 2021 | [KubeCon + CloudnativeCon](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/) | Tech / Cloud / DevOps | Online/Offline | Free/Paid | n/a |
+| 14 October 2021 | [O’Reilly Radar: Data & AI](https://www.oreilly.com/online-learning/radar-event-data-ai-2021.html) | data, AI | Online | Free | n/a |
+| 19-21 October 2021 | [HashiConf Global](https://hashiconf.com/global/) | Tech / Cloud / DevOps | Online | Free | n/a |
+| 20-21 October 2021 | [VUW.JS Live](https://vuejslive.com/) | Vue JS | Online & London (UK) | Range from €17-350 | n/a |
+| 20-22 October 2021 | [Twilio Signal](https://signal.twilio.com/) | Twilio | Online / US | Free / USD 200 | n/a |
+| 22-23 October 2021 | [Git Commit Show](https://gitcommit.show/) | Software Development | Online | Free| n/a |
 
 https://ignite.paloaltonetworks.com/

--- a/README.md
+++ b/README.md
@@ -6,13 +6,6 @@ Past events should be moved to the file PAST.md (in the same repo as this file) 
 
 | Date | Conference | Focus | Location | Price | CFP |
 | --- | --- | --- | --- | --- | --- |
-| 12-14 October 2021 | [Google Cloud Next 2021](https://cloud.withgoogle.com/next) | All things Google Cloud | Online | Free | n/a |
-| 11-15 October 2021 | [KubeCon + CloudnativeCon](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/) | Tech / Cloud / DevOps | Online/Offline | Free/Paid | n/a |
-| 14 October 2021 | [O’Reilly Radar: Data & AI](https://www.oreilly.com/online-learning/radar-event-data-ai-2021.html) | data, AI | Online | Free | n/a |
-| 19-21 October 2021 | [HashiConf Global](https://hashiconf.com/global/) | Tech / Cloud / DevOps | Online | Free | n/a |
-| 20-21 October 2021 | [VUW.JS Live](https://vuejslive.com/) | Vue JS | Online & London (UK) | Range from €17-350 | n/a |
-| 20-22 October 2021 | [Twilio Signal](https://signal.twilio.com/) | Twilio | Online / US | Free / USD 200 | n/a |
-| 22-23 October 2021 | [Git Commit Show](https://gitcommit.show/) | Software Development | Online | Free| n/a |
 | 22 & 25 October 2021 | [React Advanced London](https://reactadvanced.com/) | React/Front End | Online / London (UK) | Range from €13-570 | n/a |
 | 26 October 2021 | [NextJS CONF](https://nextjs.org/conf) | NextJS | Online / US | Free | n/a |
 | 1-31 October 2021 | [AWS Awesome Day](https://aws.amazon.com/events/awsome-day/awsome-day-online/) | Cloud | Online | Free | n/a |
@@ -21,6 +14,7 @@ Past events should be moved to the file PAST.md (in the same repo as this file) 
 | 2-4 November 2021|[MICROSOFT IGNITE](https://myignite.microsoft.com/home) | Cloud | Online | Free | n/a | 
 | 8-11 November 2021 | [NVIDIA GTC](https://www.nvidia.com/gtc/) | AI, Data Science | Online | Free | n/a |
 | 9-11 November 2021 | [Kontent Horizons](https://horizons.kontent.ai/) | Kontent | Online - APAC Nov 9/North America Nov 10/Europe Nov 11 | Free | n/a |
+| 29 November - 3 December 2021 | [AWS re:Invent](https://reinvent.awsevents.com/) | Cloud | Online / Las Vegas | Free / $1799 | n/a |
 | 7-9 December 2021 | [SRE Con Americas](https://xtremejs.dev/2021/) | SRE | Online | 60$ | n/a | 
 | 23 December 2021 | [The ExtremeJS Online Conf](https://www.usenix.org/conference/srecon20americas/) | JavaScript | Online | Fee | n/a | 
 | 9-11 February 2022 | [JS World Conference](https://jsworldconference.com/) | JavaScript | Amsterdam | € 314,54-€ 1.006,66 | [November 1, 2021](https://jsworldconference.com/speakers) | 


### PR DESCRIPTION
This PR moves past events to the "archive" and adds aws re:invent as an upcoming event. 🙂 